### PR TITLE
README.md: how to set env variable for vc7070

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,14 @@ onto an VC707 FPGA board.
 To execute these targets, you can run the following commands:
 
 ```sh
+$ export RISCV=/path/to/gcc-embedded-toolchain 
+#If gcc is installed to /home/riscv/riscv64-elf-tc/bin/riscv64-unknown-elf-gcc
+#then it will be export RISCV=/home/riscv/riscv64-elf-tc
+#Do not include /bin at the end.
+$ export PATH=${PATH}:/path/to/Xilinx/Vivado/2016.4/bin
+#If vivado is installed to /tools/Xilinx/Vivado/2016.4/bin
+#then it will be export PATH=${PATH}:/tools/Xilinx/Vivado/2016.4/bin
+#Here it must have /bin at the end.
 $ make -f Makefile.vc707-u500devkit verilog
 $ make -f Makefile.vc707-u500devkit mcs
 ```


### PR DESCRIPTION
It took me a while to figure out by reading Makefile how to set the right environment variable for RISCV and PATH when I tried to build vc707.
This might save some people who would like to try RISC-V on vc707.